### PR TITLE
use annorepo-client from maven central

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
-    <annorepo-client.version>0.3.6-beta</annorepo-client.version>
+    <annorepo-client.version>0.3.7</annorepo-client.version>
 
     <assertj-core.version>3.23.1</assertj-core.version>
     <dropwizard-swagger-ui.version>4.6.2</dropwizard-swagger-ui.version>
@@ -277,7 +277,7 @@
     </dependency>
 
     <dependency>
-      <groupId>nl.knaw.huc</groupId>
+      <groupId>io.github.knaw-huc</groupId>
       <artifactId>annorepo-client</artifactId>
       <version>${annorepo-client.version}</version>
     </dependency>


### PR DESCRIPTION
The annorepo-client library has been released to Maven Central.
I changed the annorepo dependency in pom.xml accordingly.