### PR TITLE
Ar client 0.5.1 hotfix

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>nl.knaw.huc</groupId>
     <artifactId>broccoli</artifactId>
-    <version>0.20.1</version>
+    <version>0.21.0</version>
 
     <packaging>jar</packaging>
 

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
-        <annorepo-client.version>0.5.0-beta</annorepo-client.version>
+        <annorepo-client.version>0.5.1</annorepo-client.version>
 
         <assertj-core.version>3.23.1</assertj-core.version>
         <dropwizard-swagger-ui.version>4.6.2</dropwizard-swagger-ui.version>


### PR DESCRIPTION
AnnoRepo server instances version 0.5.1 and up have a new 'mongoVersion' in their AboutInfo object which is inspected during AnnoRepo client connection attempts.
Need to use AR client 0.5.1 from here on.