### PR TITLE
make fetchTextSegmentsLocal work for index ranges with a single segment

### DIFF
--- a/src/test/kotlin/nl/knaw/huc/broccoli/resources/brinta/BrintaResourceTest.kt
+++ b/src/test/kotlin/nl/knaw/huc/broccoli/resources/brinta/BrintaResourceTest.kt
@@ -1,0 +1,23 @@
+package nl.knaw.huc.broccoli.resources.brinta
+
+import org.junit.jupiter.api.Test
+import org.assertj.core.api.Assertions.assertThat
+
+class BrintaResourceTest {
+
+    @Test
+    fun `a subsegment in a single anchor segment should work`() {
+        val textLines = listOf("Lorem ipsum dolor amet")
+        val textUrl = "https://blablabla/segments/index/0/6/0/10"
+        val textSegments = BrintaResource.fetchTextSegmentsLocal(textLines, textUrl)
+        assertThat(textSegments).containsExactly("ipsum")
+    }
+
+    @Test
+    fun `a subsegment in a multiple anchor segments should work`() {
+        val textLines = listOf("Lorem ipsum dolor amet.", "Eligendi aut nihil voluptas temporibus.")
+        val textUrl = "https://blablabla/segments/index/0/6/1/7"
+        val textSegments = BrintaResource.fetchTextSegmentsLocal(textLines, textUrl)
+        assertThat(textSegments).containsExactly("ipsum dolor amet.", "Eligendi")
+    }
+}


### PR DESCRIPTION
The hooft-brieven project has Text targets like https://brieven-van-hooft.tt.di.huc.knaw.nl/textrepo/view/versions/47858867-a96a-4d3d-8809-a7f8d33496bb/segments/index/0/187370/0/187400 that breaks the fetchTextSegmentsLocal call in BrintaResource. This PR should fix it.