### PR TITLE
Add textTokenCount (aka 'word count') to full text field

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -35,7 +35,7 @@ logging:
             - QRY
 
   loggers:
-    nl.knaw.huc: DEBUG
+    nl.knaw.huc: TRACE
     org: WARN
     org.glassfish: ERROR
     com.jayway: ERROR
@@ -60,7 +60,7 @@ projects:
       uri: https://annorepo.globalise.huygens.knaw.nl
     brinta:
       uri: http://localhost:9200
-      deleteKey: "00b9a2d3-0176-46ae-be0c-4909b1df0cfe"
+      deleteKey: 00b9a2d3-0176-46ae-be0c-4909b1df0cfe
       joinSeparator: " "
       indices:
         - name: docs

--- a/config.yml
+++ b/config.yml
@@ -173,6 +173,50 @@ projects:
     iiif:
       fixed: https://images.diginfra.net/api/pim/imageset/67533019-4ca0-4b08-b87e-fd5590e7a077/manifest
 
+  - name: 'republic'
+    tiers:
+      - name: volume
+        type: str
+      - name: opening
+        type: num
+    textType: LogicalText
+    brinta:
+      uri: http://localhost:9200
+      deleteKey: 'republic-acc-mag-weg'
+      joinSeparator: " "
+      indices:
+        - name: 'republic-wordcount'
+          bodyTypes: [ Resolution, AttendanceList ]
+          fields:
+            - name: bodyType
+              path: "$.body.type"
+              type: keyword
+            - name: sessionDate
+              path: "$.body.metadata.sessionDate"
+              type: date
+            - name: sessionDay
+              path: "$.body.metadata.sessionDay"
+              type: byte
+            - name: sessionMonth
+              path: "$.body.metadata.sessionMonth"
+              type: byte
+            - name: sessionYear
+              path: "$.body.metadata.sessionYear"
+              type: short
+            - name: sessionWeekday
+              path: "$.body.metadata.sessionWeekday"
+              type: keyword
+            - name: propositionType
+              path: "$.body.metadata.propositionType"
+              type: keyword
+    annoRepo:
+      containerName: republic-2024.01.19
+      uri: https://annorepo.republic-caf.diginfra.org
+    textRepo:
+      uri: https://textrepo.republic-caf.diginfra.org
+    iiif:
+      fixed: https://images.diginfra.net/api/pim/imageset/67533019-4ca0-4b08-b87e-fd5590e7a077/manifest
+
 
   - name: 'suriano'
     tiers:

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>nl.knaw.huc</groupId>
     <artifactId>broccoli</artifactId>
-    <version>0.30-wordcount-1</version>
+    <version>0.30-wordcount-3</version>
 
     <packaging>jar</packaging>
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>nl.knaw.huc</groupId>
     <artifactId>broccoli</artifactId>
-    <version>0.29.3</version>
+    <version>0.30.0-issue-46</version>
 
     <packaging>jar</packaging>
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>nl.knaw.huc</groupId>
     <artifactId>broccoli</artifactId>
-    <version>0.30-wordcount-0</version>
+    <version>0.30-wordcount-1</version>
 
     <packaging>jar</packaging>
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>nl.knaw.huc</groupId>
     <artifactId>broccoli</artifactId>
-    <version>0.30-wordcount-3</version>
+    <version>0.30-wordcount-4</version>
 
     <packaging>jar</packaging>
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>nl.knaw.huc</groupId>
     <artifactId>broccoli</artifactId>
-    <version>0.30.0-issue-46</version>
+    <version>0.30-wordcount-0</version>
 
     <packaging>jar</packaging>
 

--- a/src/main/kotlin/nl/knaw/huc/broccoli/api/Constants.kt
+++ b/src/main/kotlin/nl/knaw/huc/broccoli/api/Constants.kt
@@ -27,4 +27,6 @@ object Constants {
         BR_EXTERNAL_URL,
         BR_PAGE_SIZE
     }
+
+    const val TEXT_TOKEN_COUNT = "text.tokenCount"
 }

--- a/src/main/kotlin/nl/knaw/huc/broccoli/api/ElasticQuery.kt
+++ b/src/main/kotlin/nl/knaw/huc/broccoli/api/ElasticQuery.kt
@@ -9,6 +9,7 @@ import com.fasterxml.jackson.annotation.JsonProperty
 data class ElasticQuery(
     @JsonProperty("_source") val source: Boolean = true,
     @JsonProperty("track_total_hits") val trackTotalHits: Boolean = true,
+    @JsonProperty("fields") val getTextTokenCount: List<String> = listOf("text.tokenCount"),
     val from: Int,
     val size: Int,
     val sort: Sort,

--- a/src/main/kotlin/nl/knaw/huc/broccoli/api/ElasticQuery.kt
+++ b/src/main/kotlin/nl/knaw/huc/broccoli/api/ElasticQuery.kt
@@ -31,18 +31,17 @@ abstract class BaseQuery
 
 data class RangeQuery(
     @JsonIgnore val name: String,
-    @JsonIgnore val from: String,
-    @JsonIgnore val to: String,
+    @JsonIgnore val from: String?,
+    @JsonIgnore val to: String?,
     @JsonIgnore val relation: String? = "intersects"
 ) : BaseQuery() {
     @JsonAnyGetter
     fun toJson() = mapOf(
         "range" to mapOf(
-            name to mapOf(
-                "relation" to relation,
-                "gte" to from,
-                "lte" to to
-            )
+            name to mutableMapOf("relation" to relation).apply {
+                from?.let { put("gte", it) }
+                to?.let { put("lte", it) }
+            }.toMap() // back to read-only map
         )
     )
 }

--- a/src/main/kotlin/nl/knaw/huc/broccoli/api/ElasticQuery.kt
+++ b/src/main/kotlin/nl/knaw/huc/broccoli/api/ElasticQuery.kt
@@ -4,12 +4,13 @@ import com.fasterxml.jackson.annotation.JsonAnyGetter
 import com.fasterxml.jackson.annotation.JsonIgnore
 import com.fasterxml.jackson.annotation.JsonInclude
 import com.fasterxml.jackson.annotation.JsonProperty
+import nl.knaw.huc.broccoli.api.Constants.TEXT_TOKEN_COUNT
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
 data class ElasticQuery(
     @JsonProperty("_source") val source: Boolean = true,
     @JsonProperty("track_total_hits") val trackTotalHits: Boolean = true,
-    @JsonProperty("fields") val getTextTokenCount: List<String> = listOf("text.tokenCount"),
+    @JsonProperty("fields") val getTextTokenCount: List<String> = listOf(TEXT_TOKEN_COUNT),
     val from: Int,
     val size: Int,
     val sort: Sort,

--- a/src/main/kotlin/nl/knaw/huc/broccoli/api/ElasticQuery.kt
+++ b/src/main/kotlin/nl/knaw/huc/broccoli/api/ElasticQuery.kt
@@ -28,16 +28,17 @@ data class BoolQuery(
 
 abstract class BaseQuery
 
-data class DateQuery(
+data class RangeQuery(
     @JsonIgnore val name: String,
     @JsonIgnore val from: String,
-    @JsonIgnore val to: String
+    @JsonIgnore val to: String,
+    @JsonIgnore val relation: String? = "intersects"
 ) : BaseQuery() {
     @JsonAnyGetter
     fun toJson() = mapOf(
         "range" to mapOf(
             name to mapOf(
-                "relation" to "within",
+                "relation" to relation,
                 "gte" to from,
                 "lte" to to
             )

--- a/src/main/kotlin/nl/knaw/huc/broccoli/api/IndexQuery.kt
+++ b/src/main/kotlin/nl/knaw/huc/broccoli/api/IndexQuery.kt
@@ -16,6 +16,6 @@ typealias IndexTerms = Map<String, List<String>>
 
 data class IndexRange(
     val name: String,
-    val from: String,
-    val to: String
+    val from: String?,
+    val to: String?
 )

--- a/src/main/kotlin/nl/knaw/huc/broccoli/api/IndexQuery.kt
+++ b/src/main/kotlin/nl/knaw/huc/broccoli/api/IndexQuery.kt
@@ -3,9 +3,10 @@ package nl.knaw.huc.broccoli.api
 import com.fasterxml.jackson.annotation.JsonProperty
 
 data class IndexQuery(
-    val date: IndexDate?,
+    val date: IndexRange?,
     val terms: IndexTerms?,
     val text: String?,
+    val range: IndexRange?,
 
     @JsonProperty("aggs")
     val aggregations: List<String>? = null
@@ -13,7 +14,7 @@ data class IndexQuery(
 
 typealias IndexTerms = Map<String, List<String>>
 
-data class IndexDate(
+data class IndexRange(
     val name: String,
     val from: String,
     val to: String

--- a/src/main/kotlin/nl/knaw/huc/broccoli/core/ElasticQueryBuilder.kt
+++ b/src/main/kotlin/nl/knaw/huc/broccoli/core/ElasticQueryBuilder.kt
@@ -1,7 +1,6 @@
 package nl.knaw.huc.broccoli.core
 
 import nl.knaw.huc.broccoli.api.*
-import nl.knaw.huc.broccoli.api.Constants.TEXT_TOKEN_COUNT
 import nl.knaw.huc.broccoli.config.IndexConfiguration
 import kotlin.properties.Delegates
 
@@ -54,8 +53,7 @@ class ElasticQueryBuilder(private val index: IndexConfiguration) {
 
         aggregations = (query.aggregations ?: index.fields.map { it.name })
             .mapNotNull { fieldName ->
-                if (fieldName == TEXT_TOKEN_COUNT) TermAggregation(fieldName)
-                else when (index.fields.find { it.name == fieldName }?.type) {
+                when (index.fields.find { it.name == fieldName }?.type) {
                     "keyword", "short", "byte" -> TermAggregation(fieldName)
                     "date" -> DateAggregation(fieldName)
                     else -> null

--- a/src/main/kotlin/nl/knaw/huc/broccoli/core/ElasticQueryBuilder.kt
+++ b/src/main/kotlin/nl/knaw/huc/broccoli/core/ElasticQueryBuilder.kt
@@ -48,16 +48,12 @@ class ElasticQueryBuilder(private val index: IndexConfiguration) {
         highlight = query.text
             ?.let { HighlightTerm(it, fragmentSize) },
 
-        aggregations = (query.aggregations
-            ?: index.fields.map { it.name }.plus("wordCount"))
+        aggregations = (query.aggregations ?: index.fields.map { it.name })
             .mapNotNull { fieldName ->
-                when (fieldName) {
-                    "wordCount" -> TermAggregation("wordCount")
-                    else -> when (index.fields.find { it.name == fieldName }?.type) {
-                        "keyword", "short", "byte" -> TermAggregation(fieldName)
-                        "date" -> DateAggregation(fieldName)
-                        else -> null
-                    }
+                when (index.fields.find { it.name == fieldName }?.type) {
+                    "keyword", "short", "byte" -> TermAggregation(fieldName)
+                    "date" -> DateAggregation(fieldName)
+                    else -> null
                 }
             }
             .let { Aggregations(it) }

--- a/src/main/kotlin/nl/knaw/huc/broccoli/core/ElasticQueryBuilder.kt
+++ b/src/main/kotlin/nl/knaw/huc/broccoli/core/ElasticQueryBuilder.kt
@@ -1,6 +1,7 @@
 package nl.knaw.huc.broccoli.core
 
 import nl.knaw.huc.broccoli.api.*
+import nl.knaw.huc.broccoli.api.Constants.TEXT_TOKEN_COUNT
 import nl.knaw.huc.broccoli.config.IndexConfiguration
 import kotlin.properties.Delegates
 
@@ -53,7 +54,8 @@ class ElasticQueryBuilder(private val index: IndexConfiguration) {
 
         aggregations = (query.aggregations ?: index.fields.map { it.name })
             .mapNotNull { fieldName ->
-                when (index.fields.find { it.name == fieldName }?.type) {
+                if (fieldName == TEXT_TOKEN_COUNT) TermAggregation(fieldName)
+                else when (index.fields.find { it.name == fieldName }?.type) {
                     "keyword", "short", "byte" -> TermAggregation(fieldName)
                     "date" -> DateAggregation(fieldName)
                     else -> null

--- a/src/main/kotlin/nl/knaw/huc/broccoli/core/ElasticQueryBuilder.kt
+++ b/src/main/kotlin/nl/knaw/huc/broccoli/core/ElasticQueryBuilder.kt
@@ -36,7 +36,10 @@ class ElasticQueryBuilder(private val index: IndexConfiguration) {
                         add(TermsQuery(mapOf(it.key to it.value)))
                     }
                     query.date?.let {
-                        add(DateQuery(it.name, it.from, it.to))
+                        add(RangeQuery(it.name, it.from, it.to, relation = "within"))
+                    }
+                    query.range?.let {
+                        add(RangeQuery(it.name, it.from, it.to))
                     }
                     query.text?.let {
                         add(FullTextQuery(QueryString(it)))

--- a/src/main/kotlin/nl/knaw/huc/broccoli/resources/brinta/BrintaResource.kt
+++ b/src/main/kotlin/nl/knaw/huc/broccoli/resources/brinta/BrintaResource.kt
@@ -46,7 +46,7 @@ class BrintaResource(
                 ),
                 "index_options" to "offsets",
                 "analyzer" to "fulltext_analyzer"
-            ),
+            )
         )
         index.fields.forEach { field ->
             field.type?.let { type -> properties[field.name] = mapOf("type" to type) }
@@ -369,5 +369,13 @@ class BrintaResource(
             }
         }
     }
+
+    private fun getIndex(project: Project, indexName: String?): IndexConfiguration =
+        indexName
+            ?.let {
+                project.brinta.indices.find { index -> index.name == indexName }
+                    ?: throw NotFoundException("index '$indexName' not configured for project: ${project.name}")
+            }
+            ?: project.brinta.indices[0]
 
 }

--- a/src/main/kotlin/nl/knaw/huc/broccoli/resources/brinta/BrintaResource.kt
+++ b/src/main/kotlin/nl/knaw/huc/broccoli/resources/brinta/BrintaResource.kt
@@ -369,13 +369,4 @@ class BrintaResource(
             }
         }
     }
-
-    private fun getIndex(project: Project, indexName: String?): IndexConfiguration =
-        indexName
-            ?.let {
-                project.brinta.indices.find { index -> index.name == indexName }
-                    ?: throw NotFoundException("index '$indexName' not configured for project: ${project.name}")
-            }
-            ?: project.brinta.indices[0]
-
 }

--- a/src/main/kotlin/nl/knaw/huc/broccoli/resources/brinta/BrintaResource.kt
+++ b/src/main/kotlin/nl/knaw/huc/broccoli/resources/brinta/BrintaResource.kt
@@ -16,7 +16,6 @@ import nl.knaw.huc.broccoli.api.ResourcePaths.BRINTA
 import nl.knaw.huc.broccoli.config.IndexConfiguration
 import nl.knaw.huc.broccoli.core.Project
 import nl.knaw.huc.broccoli.service.anno.AnnoRepoSearchResult
-import nl.knaw.huc.broccoli.service.wordCount
 import org.slf4j.LoggerFactory
 
 @Path("$BRINTA/{projectId}")
@@ -36,13 +35,18 @@ class BrintaResource(
         val index = getIndex(project, indexName)
         logger.info("Creating ${project.name} index: ${index.name}")
 
-        val properties = mutableMapOf<String, Any>(
+        val properties = mutableMapOf(
             "text" to mapOf(
                 "type" to "text",
+                "fields" to mapOf(
+                    "tokenCount" to mapOf(
+                        "type" to "token_count",
+                        "analyzer" to "fulltext_analyzer"
+                    )
+                ),
                 "index_options" to "offsets",
                 "analyzer" to "fulltext_analyzer"
             ),
-            "wordCount" to mapOf("type" to "integer")
         )
         index.fields.forEach { field ->
             field.type?.let { type -> properties[field.name] = mapOf("type" to type) }
@@ -208,7 +212,6 @@ class BrintaResource(
                                 logger.atTrace().log("joinedSegments.length: {}", joinedSegments.length)
 
                                 payload["text"] = joinedSegments
-                                payload["wordCount"] = joinedSegments.wordCount()
                                 ok.add(docId)
                             } else {
                                 logger.atWarn().log("Failed to fetch text for {} from {}", docId, textURL)

--- a/src/main/kotlin/nl/knaw/huc/broccoli/resources/brinta/BrintaResource.kt
+++ b/src/main/kotlin/nl/knaw/huc/broccoli/resources/brinta/BrintaResource.kt
@@ -16,6 +16,7 @@ import nl.knaw.huc.broccoli.api.ResourcePaths.BRINTA
 import nl.knaw.huc.broccoli.config.IndexConfiguration
 import nl.knaw.huc.broccoli.core.Project
 import nl.knaw.huc.broccoli.service.anno.AnnoRepoSearchResult
+import nl.knaw.huc.broccoli.service.wordCount
 import org.slf4j.LoggerFactory
 
 @Path("$BRINTA/{projectId}")
@@ -40,7 +41,8 @@ class BrintaResource(
                 "type" to "text",
                 "index_options" to "offsets",
                 "analyzer" to "fulltext_analyzer"
-            )
+            ),
+            "wordCount" to mapOf("type" to "integer")
         )
         index.fields.forEach { field ->
             field.type?.let { type -> properties[field.name] = mapOf("type" to type) }
@@ -206,6 +208,7 @@ class BrintaResource(
                                 logger.atTrace().log("joinedSegments.length: {}", joinedSegments.length)
 
                                 payload["text"] = joinedSegments
+                                payload["wordCount"] = joinedSegments.wordCount()
                                 ok.add(docId)
                             } else {
                                 logger.atWarn().log("Failed to fetch text for {} from {}", docId, textURL)

--- a/src/main/kotlin/nl/knaw/huc/broccoli/resources/projects/ProjectsResource.kt
+++ b/src/main/kotlin/nl/knaw/huc/broccoli/resources/projects/ProjectsResource.kt
@@ -15,6 +15,7 @@ import jakarta.ws.rs.core.Response
 import nl.knaw.huc.broccoli.api.Constants.AR_BODY_ID
 import nl.knaw.huc.broccoli.api.Constants.AR_BODY_TYPE
 import nl.knaw.huc.broccoli.api.Constants.AR_WITHIN_TEXT_ANCHOR_RANGE
+import nl.knaw.huc.broccoli.api.Constants.TEXT_TOKEN_COUNT
 import nl.knaw.huc.broccoli.api.Constants.isIn
 import nl.knaw.huc.broccoli.api.Constants.isNotEqualTo
 import nl.knaw.huc.broccoli.api.Constants.region
@@ -164,7 +165,7 @@ class ProjectsResource(
 
             hit["fields"]?.let { fields ->
                 @Suppress("UNCHECKED_CAST")
-                (fields as Map<String, Any>)["text.tokenCount"]?.let {
+                (fields as Map<String, Any>)[TEXT_TOKEN_COUNT]?.let {
                     put("textTokenCount", (it as List<*>).first())
                 }
             }

--- a/src/main/kotlin/nl/knaw/huc/broccoli/resources/projects/ProjectsResource.kt
+++ b/src/main/kotlin/nl/knaw/huc/broccoli/resources/projects/ProjectsResource.kt
@@ -159,9 +159,13 @@ class ProjectsResource(
             // store highlight if available
             hit["highlight"]?.let { put("_hits", it) }
 
-            // store all configured index fields with their search result, if any
             @Suppress("UNCHECKED_CAST")
             val source = hit["_source"] as Map<String, Any>
+
+            // copy implicit field 'wordCount'
+            source["wordCount"]?.let { put("wordCount", it) }
+
+            // store all configured index fields with their search result, if any
             index.fields.forEach { field ->
                 source[field.name]?.let { put(field.name, it) }
             }

--- a/src/main/kotlin/nl/knaw/huc/broccoli/resources/projects/ProjectsResource.kt
+++ b/src/main/kotlin/nl/knaw/huc/broccoli/resources/projects/ProjectsResource.kt
@@ -127,7 +127,17 @@ class ProjectsResource(
                     .request()
                     .post(Entity.json(query))
             }
-            .also { logger.trace("response: {}", it) }
+            .also {
+                if (it.status != 200) {
+                    logger.atWarn()
+                        .setMessage("ElasticSearch failed")
+                        .addKeyValue("status", it.status)
+                        .addKeyValue("query", queryString)
+                        .addKeyValue("result", it.readEntityAsJsonString())
+                        .log()
+                    throw BadRequestException("Query not understood: $queryString")
+                }
+            }
             .readEntityAsJsonString()
             .also { logger.trace("json: {}", it) }
             .let { json ->

--- a/src/main/kotlin/nl/knaw/huc/broccoli/resources/projects/ProjectsResource.kt
+++ b/src/main/kotlin/nl/knaw/huc/broccoli/resources/projects/ProjectsResource.kt
@@ -162,9 +162,12 @@ class ProjectsResource(
             @Suppress("UNCHECKED_CAST")
             val source = hit["_source"] as Map<String, Any>
 
-            @Suppress("UNCHECKED_CAST")
-            val fields = hit["fields"] as Map<String, Any>
-            fields["text.tokenCount"]?.let { put("tokenCount", it) }
+            hit["fields"]?.let { fields ->
+                @Suppress("UNCHECKED_CAST")
+                (fields as Map<String, Any>)["text.tokenCount"]?.let {
+                    put("textTokenCount", (it as List<*>).first())
+                }
+            }
 
             // store all configured index fields with their search result, if any
             index.fields.forEach { field ->

--- a/src/main/kotlin/nl/knaw/huc/broccoli/resources/projects/ProjectsResource.kt
+++ b/src/main/kotlin/nl/knaw/huc/broccoli/resources/projects/ProjectsResource.kt
@@ -162,8 +162,9 @@ class ProjectsResource(
             @Suppress("UNCHECKED_CAST")
             val source = hit["_source"] as Map<String, Any>
 
-            // copy implicit field 'wordCount'
-            source["wordCount"]?.let { put("wordCount", it) }
+            @Suppress("UNCHECKED_CAST")
+            val fields = hit["fields"] as Map<String, Any>
+            fields["text.tokenCount"]?.let { put("tokenCount", it) }
 
             // store all configured index fields with their search result, if any
             index.fields.forEach { field ->

--- a/src/main/kotlin/nl/knaw/huc/broccoli/resources/projects/ProjectsResource.kt
+++ b/src/main/kotlin/nl/knaw/huc/broccoli/resources/projects/ProjectsResource.kt
@@ -15,7 +15,6 @@ import jakarta.ws.rs.core.Response
 import nl.knaw.huc.broccoli.api.Constants.AR_BODY_ID
 import nl.knaw.huc.broccoli.api.Constants.AR_BODY_TYPE
 import nl.knaw.huc.broccoli.api.Constants.AR_WITHIN_TEXT_ANCHOR_RANGE
-import nl.knaw.huc.broccoli.api.Constants.TEXT_TOKEN_COUNT
 import nl.knaw.huc.broccoli.api.Constants.isIn
 import nl.knaw.huc.broccoli.api.Constants.isNotEqualTo
 import nl.knaw.huc.broccoli.api.Constants.region
@@ -172,13 +171,6 @@ class ProjectsResource(
 
             @Suppress("UNCHECKED_CAST")
             val source = hit["_source"] as Map<String, Any>
-
-            hit["fields"]?.let { fields ->
-                @Suppress("UNCHECKED_CAST")
-                (fields as Map<String, Any>)[TEXT_TOKEN_COUNT]?.let {
-                    put("textTokenCount", (it as List<*>).first())
-                }
-            }
 
             // store all configured index fields with their search result, if any
             index.fields.forEach { field ->

--- a/src/main/kotlin/nl/knaw/huc/broccoli/service/Util.kt
+++ b/src/main/kotlin/nl/knaw/huc/broccoli/service/Util.kt
@@ -2,9 +2,6 @@ package nl.knaw.huc.broccoli.service
 
 import com.jayway.jsonpath.ReadContext
 
-const val ANY_WHITESPACE_PAT = "\\s+"
-val ANY_WHITESPACE_REGEX = ANY_WHITESPACE_PAT.toRegex()
-
 fun <K, V> List<Map<K, V>>.groupByKey(): Map<K, V> = flatMap { it.asSequence() }.associate { it.key to it.value }
 
 // migrate to ES specific 'util'
@@ -22,5 +19,3 @@ fun extractAggregations(context: ReadContext) = context.read<Map<String, Any>>("
     ?.groupByKey()
 
 fun String.capitalize(): String = replaceFirstChar(Char::uppercase)
-
-fun String.wordCount(): Int = trim().split(ANY_WHITESPACE_REGEX).size

--- a/src/main/kotlin/nl/knaw/huc/broccoli/service/Util.kt
+++ b/src/main/kotlin/nl/knaw/huc/broccoli/service/Util.kt
@@ -23,4 +23,4 @@ fun extractAggregations(context: ReadContext) = context.read<Map<String, Any>>("
 
 fun String.capitalize(): String = replaceFirstChar(Char::uppercase)
 
-fun String.wordCount(): Int = this.trim().split(ANY_WHITESPACE_REGEX).size
+fun String.wordCount(): Int = trim().split(ANY_WHITESPACE_REGEX).size

--- a/src/main/kotlin/nl/knaw/huc/broccoli/service/Util.kt
+++ b/src/main/kotlin/nl/knaw/huc/broccoli/service/Util.kt
@@ -2,6 +2,9 @@ package nl.knaw.huc.broccoli.service
 
 import com.jayway.jsonpath.ReadContext
 
+const val ANY_WHITESPACE_PAT = "\\s+"
+val ANY_WHITESPACE_REGEX = ANY_WHITESPACE_PAT.toRegex()
+
 fun <K, V> List<Map<K, V>>.groupByKey(): Map<K, V> = flatMap { it.asSequence() }.associate { it.key to it.value }
 
 // migrate to ES specific 'util'
@@ -19,3 +22,5 @@ fun extractAggregations(context: ReadContext) = context.read<Map<String, Any>>("
     ?.groupByKey()
 
 fun String.capitalize(): String = replaceFirstChar(Char::uppercase)
+
+fun String.wordCount(): Int = this.trim().split(ANY_WHITESPACE_REGEX).size


### PR DESCRIPTION
Delegate token counting to Elastic, using the same FullTextAnalayser we use for other queries on the full text field.
Add `text.tokenCount` as a `range` query.