### PR TITLE
internalise-view-annotation-filtering

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -215,13 +215,50 @@ projects:
       uri: https://textrepo.republic-caf.diginfra.org
 
   - name: 'suriano'
-    topTierBodyType: tf:File
+    topTierBodyType: tf:Folder
+    textType: LogicalText
+    views:
+      - name: appendix
+        conf:
+          anno:
+            - path: body.type
+              value: tei:Div
+            - path: body.metadata.type
+              value: appendix
+      - name: original
+        conf:
+          anno:
+            - path: body.type
+              value: tei:Div
+            - path: body.metadata.type
+              value: original
+      - name: secretarial
+        conf:
+          anno:
+            - path: body.type
+              value: tei:Div
+            - path: body.metadata.type
+              value: secretarial
+      - name: text
+        conf:
+          anno:
+            - path: body.type
+              value: tei:Div
+            - path: body.metadata.type
+              value: text
+      - name: notes
+        conf:
+          anno:
+            - path: body.type
+              value: tei:Div
+            - path: body.metadata.type
+              value: notes
     brinta:
       uri: http://localhost:9200
-      deleteKey: "local-dev-mag-weg"
+      deleteKey: suriano-dev-mag-weg
       indices:
-        - name: letters
-          bodyTypes: [ tf:File, tei:Div ]
+        - name: suriano-0.4.5e-021
+          bodyTypes: [ LetterBody ]
           fields:
             - name: bodyType
               path: "$.body.type"
@@ -233,19 +270,25 @@ projects:
               path: "$.body.metadata.recipient"
               type: keyword
             - name: recipientLoc
-              path: "$.body.metadata.recipientloc"
+              path: "$.body.metadata.recipientLoc"
               type: keyword
             - name: sender
               path: "$.body.metadata.sender"
               type: keyword
             - name: senderLoc
-              path: "$.body.metadata.senderloc"
+              path: "$.body.metadata.senderLoc"
+              type: keyword
+            - name: editorNotes
+              path: "$.body.metadata.editorNotes"
+              type: keyword
+            - name: shelfmark
+              path: "$.body.metadata.shelfmark"
               type: keyword
             - name: summary
               path: "$.body.metadata.summary"
               type: text
     annoRepo:
-      containerName: 'suriano-0.2.0'
+      containerName: 'suriano-0.4.5e-021'
       uri: https://suriano.annorepo.dev.clariah.nl/
     textRepo:
       uri: https://suriano.tt.di.huc.knaw.nl

--- a/config.yml
+++ b/config.yml
@@ -246,13 +246,6 @@ projects:
               value: tei:Div
             - path: body.metadata.type
               value: text
-      - name: notes
-        conf:
-          anno:
-            - path: body.type
-              value: tei:Div
-            - path: body.metadata.type
-              value: notes
     brinta:
       uri: http://localhost:9200
       deleteKey: suriano-dev-mag-weg

--- a/src/main/kotlin/nl/knaw/huc/broccoli/service/Util.kt
+++ b/src/main/kotlin/nl/knaw/huc/broccoli/service/Util.kt
@@ -15,3 +15,22 @@ fun extractAggregations(context: ReadContext) = context.read<Map<String, Any>>("
         }
     }
     ?.groupByKey()
+
+inline fun <reified V> getValueAtPath(anno: Map<*, *>, path: String): V? {
+    val steps = path.split('.').iterator()
+
+    var cur: Any = anno
+    while (cur is Map<*, *>) {
+        cur = cur[steps.next()] ?: return null
+    }
+
+    if (steps.hasNext()) {
+        return null
+    }
+
+    if (cur is V) {
+        return cur
+    }
+
+    return null
+}

--- a/src/main/kotlin/nl/knaw/huc/broccoli/service/anno/AnnoRepoSearchResult.kt
+++ b/src/main/kotlin/nl/knaw/huc/broccoli/service/anno/AnnoRepoSearchResult.kt
@@ -1,10 +1,13 @@
 package nl.knaw.huc.broccoli.service.anno
 
 import com.jayway.jsonpath.DocumentContext
+import nl.knaw.huc.broccoli.service.getValueAtPath
 
 class AnnoRepoSearchResult(val context: DocumentContext) {
+    fun root(): Map<String, Any> = context.read("$")
+
     fun items(): List<Map<String, Any>> {
-        return listOf(context.read("$"))
+        return listOf(root())
     }
 
     fun bodyId(): String = context.read("$.body.id")
@@ -23,4 +26,17 @@ class AnnoRepoSearchResult(val context: DocumentContext) {
 
     fun <T> withoutField(type: String, field: String): List<Map<String, T>> =
         context.read("$.target[?(@.type == '$type')][?(@.$field == null)]")
+
+    fun liesWithin(region: IntRange) =
+        target<Any>("Text")
+            .any { target ->
+                getValueAtPath<Int>(target, "selector.start")?.let { start ->
+                    getValueAtPath<Int>(target, "selector.end")?.let { end ->
+                        start >= region.first && end <= region.last
+                    } ?: false
+                } ?: false
+            }
+
+    fun satisfies(constraints: Map<String, String>) =
+        constraints.all { (path, value) -> read("$.$path") == value }
 }


### PR DESCRIPTION

Pre-fetch all overlapping anno's in bulk, then do local filtering on constraints and inclusion for each view. This saves numerous AnnoRepo calls from previous implementation.