### PR TITLE
refine-logging

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>nl.knaw.huc</groupId>
     <artifactId>broccoli</artifactId>
-    <version>0.40.2</version>
+    <version>0.40.1</version>
 
     <packaging>jar</packaging>
 
@@ -27,7 +27,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
-        <annorepo-client.version>0.7.0</annorepo-client.version>
+        <annorepo-client.version>0.6.3</annorepo-client.version>
 
         <assertj-core.version>3.26.3</assertj-core.version>
         <dropwizard-swagger-ui.version>4.6.2</dropwizard-swagger-ui.version>
@@ -38,7 +38,7 @@
         <mockito-kotlin.version>5.1.0</mockito-kotlin.version>
         <mockito.version>5.5.0</mockito.version>
 
-        <maven-compiler-plugin.version>3.13.0</maven-compiler-plugin.version>
+        <maven-compiler-plugin.version>3.11.0</maven-compiler-plugin.version>
         <maven-jar-plugin.version>3.3.0</maven-jar-plugin.version>
         <maven-javadoc-plugin.version>3.5.0</maven-javadoc-plugin.version>
         <maven-project-info-reports-plugin.version>3.4.3</maven-project-info-reports-plugin.version>

--- a/src/main/kotlin/nl/knaw/huc/broccoli/api/IndexQuery.kt
+++ b/src/main/kotlin/nl/knaw/huc/broccoli/api/IndexQuery.kt
@@ -12,10 +12,14 @@ data class IndexQuery(
     val aggregations: Map<String, Map<String, Any>>? = null
 ) {
     override fun toString(): String = buildString {
-        text?.let { append(it).append('|') }
-        date?.let { append(it).append('|') }
-        range?.let { append(it).append('|') }
-        terms?.let { append(it).append('|') }
+        text?.let { append(it) }
+        append('|')
+        terms?.let { append(it) }
+        append('|')
+        date?.let { append(it) }
+        append('|')
+        range?.let { append(it) }
+        append('|')
     }
 }
 

--- a/src/main/kotlin/nl/knaw/huc/broccoli/resources/projects/ProjectsResource.kt
+++ b/src/main/kotlin/nl/knaw/huc/broccoli/resources/projects/ProjectsResource.kt
@@ -105,14 +105,14 @@ class ProjectsResource(
             .fragmentSize(fragmentSize)
 
         val baseQuery = queryBuilder.toElasticQuery()
-        logger.debug("base ES query: {}", jsonWriter.writeValueAsString(baseQuery))
+        logger.atTrace().addKeyValue("ES query", jsonWriter.writeValueAsString(baseQuery)).log("base")
 
         val baseResult = client
             .target(project.brinta.uri).path(index.name).path("_search")
             .request().post(Entity.json(baseQuery))
         validateElasticResult(baseResult, queryString)
         val baseJson = baseResult.readEntityAsJsonString()
-            .also { logger.trace("base json: {}", it) }
+        logger.atTrace().addKeyValue("json", baseJson).log("base")
 
         val result: MutableMap<String, Any> = mutableMapOf()
         val aggs: MutableMap<String, Any> = mutableMapOf()
@@ -121,7 +121,7 @@ class ProjectsResource(
                 ?.let { result["total"] = it }
 
             extractAggregations(index, context)?.let { aggs.putAll(it) }
-            logger.atDebug().addKeyValue("aggs", aggs).log("base")
+            logger.atTrace().addKeyValue("aggs", aggs).log("base")
 
             context.read<List<Map<String, Any>>>("$.hits.hits[*]")
                 ?.map { buildHitResult(index, it) }
@@ -130,12 +130,14 @@ class ProjectsResource(
 
         val auxQueries = queryBuilder.toMultiFacetCountQueries()
         auxQueries.forEachIndexed { auxIndex, auxQuery ->
-            logger.atDebug().log("aux ES query[$auxIndex]: ${jsonWriter.writeValueAsString(auxQuery)}")
+            logger.atTrace().addKeyValue("query[$auxIndex]", jsonWriter.writeValueAsString(auxQuery)).log("aux")
+
             val auxResult = client.target(project.brinta.uri).path(index.name).path("_search")
                 .request().post(Entity.json(auxQuery))
             validateElasticResult(auxResult, queryString)
             val auxJson = auxResult.readEntityAsJsonString()
-                .also { logger.trace("aux json[{}]: {}", auxIndex, it) }
+            logger.atTrace().addKeyValue("json", auxJson).log("aux")
+
             jsonParser.parse(auxJson).let { context ->
                 extractAggregations(index, context)
                     ?.forEach { entry ->
@@ -189,7 +191,9 @@ class ProjectsResource(
             return
         }
 
-        logger.atDebug().addMarker(queryMarker).setMessage("${query}from=$from|size=$size").log()
+        logger.atInfo()
+            .addMarker(queryMarker)
+            .log("${query}from=$from|size=$size")
     }
 
     private fun buildHitResult(index: IndexConfiguration, hit: Map<String, Any>) =

--- a/src/main/kotlin/nl/knaw/huc/broccoli/resources/projects/ProjectsResource.kt
+++ b/src/main/kotlin/nl/knaw/huc/broccoli/resources/projects/ProjectsResource.kt
@@ -184,12 +184,12 @@ class ProjectsResource(
     }
 
     private fun logQuery(query: IndexQuery, from: Int, size: Int) {
-        if (query.text != null) {
-            logger.atDebug()
-                .addMarker(queryMarker)
-                .setMessage("${query}from=$from|size=$size")
-                .log()
+        if (query.text.isNullOrBlank() && query.terms.isNullOrEmpty()) {
+            // nothing useful to log
+            return
         }
+
+        logger.atDebug().addMarker(queryMarker).setMessage("${query}from=$from|size=$size").log()
     }
 
     private fun buildHitResult(index: IndexConfiguration, hit: Map<String, Any>) =


### PR DESCRIPTION
* various stages of query execution now logged at TRACE rather than DEBUG level as they are quite 'spammy'. This enables us to have less spam on the production server logs.
* log user query when either text or terms (or both) have a value
* always log '|' separators in user query log, so parsing of fields is no longer ambiguous.