### PR TITLE
Api versioning

### DIFF
--- a/src/main/kotlin/nl/knaw/huc/broccoli/BroccoliApplication.kt
+++ b/src/main/kotlin/nl/knaw/huc/broccoli/BroccoliApplication.kt
@@ -85,7 +85,6 @@ class BroccoliApplication : Application<BroccoliConfiguration>() {
             val v2 = V2ProjectsResource(projects)
             register(AboutResource(configuration, name, appVersion))
             register(HomePageResource())
-            register(V2ProjectsResource(projects))
             register(ProjectsResource(projects, client, jsonParser, objectMapper, v1, v2))
             register(BrintaResource(projects, client))
         }

--- a/src/main/kotlin/nl/knaw/huc/broccoli/BroccoliApplication.kt
+++ b/src/main/kotlin/nl/knaw/huc/broccoli/BroccoliApplication.kt
@@ -2,7 +2,6 @@ package nl.knaw.huc.broccoli
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.module.kotlin.registerKotlinModule
-import com.fasterxml.jackson.module.paramnames.ParameterNamesModule
 import com.jayway.jsonpath.Configuration
 import com.jayway.jsonpath.JsonPath
 import com.jayway.jsonpath.Option
@@ -28,7 +27,9 @@ import nl.knaw.huc.broccoli.core.Project
 import nl.knaw.huc.broccoli.resources.AboutResource
 import nl.knaw.huc.broccoli.resources.HomePageResource
 import nl.knaw.huc.broccoli.resources.brinta.BrintaResource
+import nl.knaw.huc.broccoli.resources.projects.V1ProjectsResource
 import nl.knaw.huc.broccoli.resources.projects.ProjectsResource
+import nl.knaw.huc.broccoli.resources.projects.V2ProjectsResource
 import nl.knaw.huc.broccoli.service.anno.AnnoRepo
 import nl.knaw.huc.broccoli.service.text.TextRepo
 import org.eclipse.jetty.servlets.CrossOriginFilter
@@ -80,9 +81,12 @@ class BroccoliApplication : Application<BroccoliConfiguration>() {
         val objectMapper = createJsonMapper()
 
         with(environment.jersey()) {
+            val v1 = V1ProjectsResource(projects)
+            val v2 = V2ProjectsResource(projects)
             register(AboutResource(configuration, name, appVersion))
             register(HomePageResource())
-            register(ProjectsResource(projects, client, jsonParser, objectMapper))
+            register(V2ProjectsResource(projects))
+            register(ProjectsResource(projects, client, jsonParser, objectMapper, v1, v2))
             register(BrintaResource(projects, client))
         }
 

--- a/src/main/kotlin/nl/knaw/huc/broccoli/api/ResourcePaths.kt
+++ b/src/main/kotlin/nl/knaw/huc/broccoli/api/ResourcePaths.kt
@@ -1,6 +1,8 @@
 package nl.knaw.huc.broccoli.api
 
 object ResourcePaths {
+    const val V1 = "v1"
+    const val V2 = "v2"
     const val ABOUT = "about"
     const val PROJECTS = "projects"
     const val BRINTA = "brinta"

--- a/src/main/kotlin/nl/knaw/huc/broccoli/resources/projects/ProjectsResource.kt
+++ b/src/main/kotlin/nl/knaw/huc/broccoli/resources/projects/ProjectsResource.kt
@@ -8,10 +8,7 @@ import jakarta.validation.constraints.Min
 import jakarta.ws.rs.*
 import jakarta.ws.rs.client.Client
 import jakarta.ws.rs.client.Entity
-import jakarta.ws.rs.core.GenericType
-import jakarta.ws.rs.core.HttpHeaders
-import jakarta.ws.rs.core.MediaType
-import jakarta.ws.rs.core.Response
+import jakarta.ws.rs.core.*
 import nl.knaw.huc.broccoli.api.Constants.AR_BODY_TYPE
 import nl.knaw.huc.broccoli.api.Constants.isIn
 import nl.knaw.huc.broccoli.api.IndexQuery
@@ -37,7 +34,9 @@ class ProjectsResource(
     private val projects: Map<String, Project>,
     private val client: Client,
     private val jsonParser: ParseContext,
-    private val jsonWriter: ObjectMapper
+    private val jsonWriter: ObjectMapper,
+    private val v1: V1ProjectsResource,
+    private val v2: V2ProjectsResource
 ) {
     init {
         logger.info("init: projects=$projects, client=$client")
@@ -46,7 +45,15 @@ class ProjectsResource(
     @GET
     @Path("")
     @Operation(summary = "Get configured projects")
-    fun listProjects(): Set<String> = projects.keys
+    fun listProjects(
+        @PathParam("version") version: String
+    ): Set<String> {
+        return if(version == V1) {
+            this.v1.listProjects()
+        } else {
+            this.v2.listProjects()
+        }
+    }
 
     @GET
     @Path("{projectId}")

--- a/src/main/kotlin/nl/knaw/huc/broccoli/resources/projects/ProjectsResource.kt
+++ b/src/main/kotlin/nl/knaw/huc/broccoli/resources/projects/ProjectsResource.kt
@@ -16,6 +16,8 @@ import nl.knaw.huc.broccoli.api.Constants.AR_BODY_TYPE
 import nl.knaw.huc.broccoli.api.Constants.isIn
 import nl.knaw.huc.broccoli.api.IndexQuery
 import nl.knaw.huc.broccoli.api.ResourcePaths.PROJECTS
+import nl.knaw.huc.broccoli.api.ResourcePaths.V1
+import nl.knaw.huc.broccoli.api.ResourcePaths.V2
 import nl.knaw.huc.broccoli.api.TextMarker
 import nl.knaw.huc.broccoli.config.IndexConfiguration
 import nl.knaw.huc.broccoli.core.ElasticQueryBuilder
@@ -29,7 +31,7 @@ import nl.knaw.huc.broccoli.service.text.TextRepo
 import org.slf4j.LoggerFactory
 import org.slf4j.MarkerFactory
 
-@Path(PROJECTS)
+@Path("{version:$V1|$V2}/$PROJECTS")
 @Produces(MediaType.APPLICATION_JSON)
 class ProjectsResource(
     private val projects: Map<String, Project>,

--- a/src/main/kotlin/nl/knaw/huc/broccoli/resources/projects/V1ProjectsResource.kt
+++ b/src/main/kotlin/nl/knaw/huc/broccoli/resources/projects/V1ProjectsResource.kt
@@ -1,0 +1,19 @@
+package nl.knaw.huc.broccoli.resources.projects
+
+import nl.knaw.huc.broccoli.core.Project
+import org.slf4j.LoggerFactory
+
+class V1ProjectsResource(
+    private val projects: Map<String, Project>,
+) {
+
+    fun listProjects(): Set<String> {
+        logger.info("List projects v1")
+        return projects.keys
+    }
+
+    companion object {
+        private val logger = LoggerFactory.getLogger(V1ProjectsResource::class.java)
+    }
+
+}

--- a/src/main/kotlin/nl/knaw/huc/broccoli/resources/projects/V2ProjectsResource.kt
+++ b/src/main/kotlin/nl/knaw/huc/broccoli/resources/projects/V2ProjectsResource.kt
@@ -1,0 +1,19 @@
+package nl.knaw.huc.broccoli.resources.projects
+
+import nl.knaw.huc.broccoli.core.Project
+import org.slf4j.LoggerFactory
+
+class V2ProjectsResource(
+    private val projects: Map<String, Project>,
+) {
+
+    fun listProjects(): Set<String> {
+        logger.info("List projects v2")
+        return projects.keys
+    }
+
+    companion object {
+        private val logger = LoggerFactory.getLogger(V2ProjectsResource::class.java)
+    }
+
+}

--- a/src/test/kotlin/nl/knaw/huc/broccoli/resources/projects/ProjectsResourceTest.kt
+++ b/src/test/kotlin/nl/knaw/huc/broccoli/resources/projects/ProjectsResourceTest.kt
@@ -12,6 +12,8 @@ import jakarta.ws.rs.core.Response
 import nl.knaw.huc.broccoli.BroccoliApplication
 import nl.knaw.huc.broccoli.api.IndexQuery
 import nl.knaw.huc.broccoli.api.ResourcePaths.PROJECTS
+import nl.knaw.huc.broccoli.api.ResourcePaths.V1
+import nl.knaw.huc.broccoli.api.ResourcePaths.V2
 import nl.knaw.huc.broccoli.config.BroccoliConfiguration
 import nl.knaw.huc.broccoli.service.readEntityAsJsonString
 import org.assertj.core.api.Assertions.assertThat
@@ -52,14 +54,45 @@ class ProjectsResourceTest {
     }
 
     @Test
-    fun `ProjectsResource should list projects`() {
+    fun `ProjectsResource should list projects at v1`() {
         val response: Response =
-            application.client().target(toUrl("/$PROJECTS"))
+            application.client().target(toUrl("/$V1/$PROJECTS"))
                 .request()
                 .get()
         assertThat(response.status)
             .isEqualTo(Response.Status.OK.statusCode)
         assertThat(response.readEntityAsJsonString()).isEqualTo("[\"${projectId}\"]")
+    }
+
+    @Test
+    fun `ProjectsResource should list projects at v2`() {
+        val response: Response =
+            application.client().target(toUrl("/$V2/$PROJECTS"))
+                .request()
+                .get()
+        assertThat(response.status)
+            .isEqualTo(Response.Status.OK.statusCode)
+        assertThat(response.readEntityAsJsonString()).isEqualTo("[\"${projectId}\"]")
+    }
+
+    @Test
+    fun `ProjectsResource does not list projects at v3`() {
+        val response: Response =
+            application.client().target(toUrl("/v3/$PROJECTS"))
+                .request()
+                .get()
+        assertThat(response.status)
+            .isEqualTo(Response.Status.NOT_FOUND.statusCode)
+    }
+
+    @Test
+    fun `ProjectsResource does not list projects at root`() {
+        val response: Response =
+            application.client().target(toUrl("/$PROJECTS"))
+                .request()
+                .get()
+        assertThat(response.status)
+            .isEqualTo(Response.Status.NOT_FOUND.statusCode)
     }
 
     @Test
@@ -83,7 +116,7 @@ class ProjectsResourceTest {
         )
 
         val query: IndexQuery = Gson().fromJson(request, IndexQuery::class.java)
-        val target = toUrl("/$PROJECTS/${projectId}/search")
+        val target = toUrl("/v1/$PROJECTS/${projectId}/search")
         val response: Response =
             application.client()
                 .target(target)

--- a/src/test/kotlin/nl/knaw/huc/broccoli/resources/projects/ProjectsResourceTest.kt
+++ b/src/test/kotlin/nl/knaw/huc/broccoli/resources/projects/ProjectsResourceTest.kt
@@ -34,7 +34,6 @@ class ProjectsResourceTest {
     var projectId = "dummy"
     lateinit var application: DropwizardAppExtension<BroccoliConfiguration>
 
-
     @BeforeAll
     fun setup() {
         mockServer =
@@ -116,7 +115,7 @@ class ProjectsResourceTest {
         )
 
         val query: IndexQuery = Gson().fromJson(request, IndexQuery::class.java)
-        val target = toUrl("/v1/$PROJECTS/${projectId}/search")
+        val target = toUrl("/v2/$PROJECTS/${projectId}/search")
         val response: Response =
             application.client()
                 .target(target)


### PR DESCRIPTION
Example of how we could organize API versioning. When versioning, initially most endpoints will be the same between v1 and v2. This setup prevents us from duplicating the v1 resources for the v2 API. Instead the resource path parameter catches both v1 and v2 requests. Only the endpoints that actually differ have some extra logic to determine if the v1 or v2 endpoint is needed.

When v2 starts to differ from v1, we could decide to split the v1 and v2 resources completely.

Interesting lines:
- [@Path](https://github.com/knaw-huc/broccoli/compare/integration-test...api-versioning?expand=1#diff-87394ea252cccb89a0835d084cbaa0d23a1db99c37e1640486922f238b35d78cR31) regex to capture multiple paths
- Version [@PathParam](https://github.com/knaw-huc/broccoli/compare/integration-test...api-versioning?expand=1#diff-87394ea252cccb89a0835d084cbaa0d23a1db99c37e1640486922f238b35d78cR50) to determine which endpoint should be called.