### PR TITLE
Limit keyword aggs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>nl.knaw.huc</groupId>
     <artifactId>broccoli</artifactId>
-    <version>0.40.3</version>
+    <version>0.40.4-limit-keyword-aggs</version>
 
     <packaging>jar</packaging>
 


### PR DESCRIPTION
Limits the returned aggregate values from Elastic to those that were actually requested in the `terms` part of the query.

For mutually exclusive keyword facets this happens by nature of them being mutually exclusive.
For multi-value keyword facets, we now do this 'by hand'.