### PR TITLE
Flush cache before indexing

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -65,78 +65,6 @@ projects:
     textRepo:
       uri: https://globalise.tt.di.huc.knaw.nl
 
-  - name: "mondriaan"
-    views:
-      - name: textOrig
-        conf:
-          anno:
-            - path: body.type
-              value: tei:Div
-            - path: body.metadata.type
-              value: original
-      - name: textTrans
-        conf:
-          anno:
-            - path: body.type
-              value: tei:Div
-            - path: body.metadata.type
-              value: translation
-      - name: notesEN
-        conf:
-          anno:
-            - path: body.type
-              value: tei:Note
-            - path: body.metadata.lang
-              value: en
-      - name: title
-        conf:
-          anno:
-            - path: body.type
-              value: tei:Title
-      - name: postalData
-        conf:
-          anno:
-            - path: body.type
-              value: tei:Div
-            - path: body.metadata.type
-              value: postalData
-    brinta:
-      uri: http://localhost:9200
-      deleteKey: "mondriaan-dev-mag-weg"
-      indices:
-        - name: divs
-          bodyTypes: [tf:Letter, tei:Div, tei:Rs]
-          fields:
-            - name: bodyType
-              path: "$.body.type"
-            - name: lang
-              path: "$.body.metadata.lang"
-            - name: type
-              path: "$.body.metadata.type"
-            - name: anno
-              path: "$.body.metadata.anno"
-            - name: country
-              path: "$.body.metadata.country"
-            - name: institution
-              path: "$.body.metadata.institution"
-            - name: msid
-              path: "$.body.metadata.msid"
-            - name: period
-              path: "$.body.metadata.period"
-            - name: periodLong
-              path: "$.body.metadata.periodlong"
-            - name: letterId
-              path: "$.body.metadata.letterid"
-            - name: correspondent
-              path: "$.body.metadata.correspondent"
-            - name: location
-              path: "$.body.metadata.location"
-    annoRepo:
-      containerName: "mondriaan-0.9.0"
-      uri: https://mondriaan.annorepo.dev.clariah.nl
-    textRepo:
-      uri: https://mondriaan.tt.di.huc.knaw.nl
-
   - name: "republic"
     topTierBodyType: Volume
     textType: LogicalText
@@ -411,24 +339,32 @@ projects:
   #      uri: https://suriano.annorepo.dev.clariah.nl/
   #    textRepo:
   #      uri: https://suriano.tt.di.huc.knaw.nl
-  #
-  - name: "hooft"
-    annoRepo:
-      containerName: "brieven-van-hooft"
-      uri: https://brieven-van-hooft.annorepo.dev.clariah.nl/
-    brinta:
-      uri: http://localhost:9200
-      deleteKey: hooft-dev-mag-weg
-      indices:
-        - name: letters-2024-03-28
-          bodyTypes: [Letter]
-          fields:
-            - name: bodyType
-              path: "$.body.type"
-    textRepo:
-      uri: https://brieven-van-hooft.tt.di.huc.knaw.nl
-
+  
   - name: "vangogh"
+    topTierBodyType: tf:Letter
+    textType: LogicalText
+    annoRepo:
+      containerName: vangogh
+      uri: https://preview.dev.diginfra.org/annorepo
+    brinta:
+      uri: http://brinta:9200
+      deleteKey: peen-vangogh-mag-weg
+      indices:
+        - name: vangogh
+          bodyTypes: [tf:LetterBody]
+          fields:
+            - name: correspondent
+              path: "$.body.metadata.correspondent"
+            - name: file
+              path: "$.body.metadata.file"
+            - name: location
+              path: "$.body.metadata.location"
+            - name: period
+              path: "$.body.metadata.period"
+            - name: periodLong
+              path: "$.body.metadata.periodLong"
+            - name: sender
+              path: "$.body.metadata.sender"
     views:
       - name: textOrig
         conf:
@@ -444,27 +380,3 @@ projects:
               value: tei:Div
             - path: body.metadata.type
               value: translation
-    brinta:
-      deleteKey: vangogh-dev-mag-weg
-      uri: http://localhost:9200
-      indices:
-        - name: "letters-vangogh-0.2.0"
-          bodyTypes: [tf:Letter]
-          fields:
-            - name: correspondent
-              path: "$.body.metadata.correspondent"
-            - name: institution
-              path: "$.body.metadata.institution"
-            - name: location
-              path: "$.body.metadata.location"
-            - name: msid
-              path: "$.body.metadata.msid"
-            - name: period
-              path: "$.body.metadata.period"
-            - name: periodLong
-              path: "$.body.metadata.periodLong"
-    annoRepo:
-      containerName: "vangogh-0.2.0"
-      uri: https://vangogh.annorepo.dev.clariah.nl
-    textRepo:
-      uri: https://vangogh.tt.di.huc.knaw.nl

--- a/src/main/kotlin/nl/knaw/huc/broccoli/resources/brinta/BrintaResource.kt
+++ b/src/main/kotlin/nl/knaw/huc/broccoli/resources/brinta/BrintaResource.kt
@@ -147,6 +147,9 @@ class BrintaResource(
 
         val index = getIndex(project, indexName)
 
+        // assume AnnoRepo may just have had new data uploaded, so invalidate query cache
+        project.annoRepo.invalidateCache()
+
         val metadataKey = metaAnno ?: project.topTierBodyType
         val requestedMetadataPairs = metaValues
             ?.split(',')

--- a/src/main/kotlin/nl/knaw/huc/broccoli/resources/projects/ProjectsResource.kt
+++ b/src/main/kotlin/nl/knaw/huc/broccoli/resources/projects/ProjectsResource.kt
@@ -55,10 +55,14 @@ class ProjectsResource(
         Response.ok(it.annoRepo.findDistinct(AR_BODY_TYPE)).build()
     }
 
-    @GET
-    @Path("{projectId}/views")
-    fun getViews(@PathParam("projectId") projectId: String) = getProject(projectId).views
-
+    @DELETE
+    @Path("{projectId}/cache")
+    fun invalidateCache(
+        @PathParam("projectId") projectId: String
+    ): Response {
+        getProject(projectId).annoRepo.invalidateCache()
+        return Response.noContent().build()
+    }
 
     @POST
     @Path("{projectId}/search")
@@ -173,6 +177,10 @@ class ProjectsResource(
 
         return Response.ok(result).build()
     }
+
+    @GET
+    @Path("{projectId}/views")
+    fun getViews(@PathParam("projectId") projectId: String) = getProject(projectId).views
 
     private fun validateElasticResult(result: Response, queryString: IndexQuery) {
         if (result.status != 200) {

--- a/src/main/kotlin/nl/knaw/huc/broccoli/service/anno/AnnoRepo.kt
+++ b/src/main/kotlin/nl/knaw/huc/broccoli/service/anno/AnnoRepo.kt
@@ -57,6 +57,10 @@ class AnnoRepo(
         return value
     }
 
+    fun invalidateCache() = cachedQueryResults
+        .also { log.debug("invalidateCache: deleting ${it.size()} cached queries") }
+        .clear()
+
     fun findByMetadata(bodyType: String, metadata: List<Pair<String, String>>) =
         mutableMapOf("body.type" to bodyType).apply {
             metadata.forEach { put("body.metadata.${it.first}", it.second) }

--- a/src/main/kotlin/nl/knaw/huc/broccoli/service/cache/LRUCache.kt
+++ b/src/main/kotlin/nl/knaw/huc/broccoli/service/cache/LRUCache.kt
@@ -27,5 +27,9 @@ class LRUCache<K, V>(private val capacity: Int = 5) {
         return evictedKey
     }
 
+    fun clear() = cache.clear()
+
+    fun size() = cache.size
+
     override fun toString(): String = cache.toString()
 }


### PR DESCRIPTION
Flush any AnnoRepo results when (re-)indexing an AR container.

- For 🥕 we re-use AR containers with the same name over and over again. When indexing, we need to ensure that we don't have any old results cached, so invalidate the AR query cache.
- As a convenience / for testing: also adds a `DELETE` endpoint at `projects/$projectId/cache`

Caveats:
- Branchname is a misnomer: during coding I realized cache should be flushed _before_ indexing, not _after_;
- Side effect: clean up obsolete configs for old containers.