### PR TITLE
Revert 7734ea2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <groupId>nl.knaw.huc</groupId>
     <artifactId>broccoli</artifactId>
 
-    <version>0.40.5</version>
+    <version>0.41-tokencount-in-result-0</version>
 
     <packaging>jar</packaging>
 
@@ -105,8 +105,10 @@
                 <configuration>
                     <createDependencyReducedPom>true</createDependencyReducedPom>
                     <transformers>
-                        <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
-                        <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                        <transformer
+                                implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
+                        <transformer
+                                implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
                             <mainClass>${mainClass}</mainClass>
                         </transformer>
                     </transformers>
@@ -143,8 +145,10 @@
                         </goals>
                         <configuration>
                             <transformers>
-                                <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
-                                <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                                <transformer
+                                        implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
+                                <transformer
+                                        implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
                                     <mainClass>${mainClass}</mainClass>
                                 </transformer>
                             </transformers>

--- a/src/main/kotlin/nl/knaw/huc/broccoli/resources/projects/ProjectsResource.kt
+++ b/src/main/kotlin/nl/knaw/huc/broccoli/resources/projects/ProjectsResource.kt
@@ -13,6 +13,7 @@ import jakarta.ws.rs.core.HttpHeaders
 import jakarta.ws.rs.core.MediaType
 import jakarta.ws.rs.core.Response
 import nl.knaw.huc.broccoli.api.Constants.AR_BODY_TYPE
+import nl.knaw.huc.broccoli.api.Constants.TEXT_TOKEN_COUNT
 import nl.knaw.huc.broccoli.api.Constants.isIn
 import nl.knaw.huc.broccoli.api.IndexQuery
 import nl.knaw.huc.broccoli.api.ResourcePaths.PROJECTS
@@ -217,6 +218,13 @@ class ProjectsResource(
 
             @Suppress("UNCHECKED_CAST")
             val source = hit["_source"] as Map<String, Any>
+
+            hit["fields"]?.let { fields ->
+                @Suppress("UNCHECKED_CAST")
+                (fields as Map<String, Any>)[TEXT_TOKEN_COUNT]?.let {
+                    put("textTokenCount", (it as List<*>).first())
+                }
+            }
 
             // store all configured index fields with their search result, if any
             index.fields.forEach { field ->


### PR DESCRIPTION
Reinstates showing `textTokenCount`, if available, in hit results.
This feature was removed in commit 7734ea2 as it wasn't used, but is now requested back.